### PR TITLE
A simple change in the response message format

### DIFF
--- a/src/__tests__/api/messages.test.ts
+++ b/src/__tests__/api/messages.test.ts
@@ -16,8 +16,9 @@ describe('/api/messages', () => {
     expect(res._getStatusCode()).toBe(200);
     const data = JSON.parse(res._getData());
     expect(data).toHaveProperty('response');
-    expect(data.response).toContain('Message accepted');
-    expect(data.response).toContain(`length:${testMessage.length}`);
+    expect(data.response).toMatch(
+      /^Message accepted, length: \d+ on \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC$/
+    );
   });
 
   it('returns 405 for non-POST requests', async () => {

--- a/src/pages/api/messages.ts
+++ b/src/pages/api/messages.ts
@@ -42,12 +42,20 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
   // Format current date
   const now = new Date();
-  const formattedDate = now.toISOString()
-    .replace(/[-:]/g, '')
-    .split('.')[0]
-    .replace('T', ' ') + ' UTC';
+  const formattedDate = formatDate(now);
 
-  const response = `Message accepted, length:${message.length} at date:${formattedDate}`;
+  const response = `Message accepted, length:${message.length} on ${formattedDate} UTC`;
 
   res.status(200).json({ response });
+}
+
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+  
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 } 


### PR DESCRIPTION
The main idea was to check if it can follow the contributing guidelines.  Prompt: 

The way I see responses in the browser is
Message accepted, length:16 at date:20250203 214011 UTC

I don't like how "at date" sounds, please fix the language. 
Spaces after : would improve readability 
Also date requires dashes, and time requires colons

Work across project to fix that, respect Contributing guidelines