### PR TITLE
Changed the logic of user registration

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -6,7 +6,7 @@
 -- Stores user account information
 CREATE TABLE users (
     id UUID PRIMARY KEY,                                    -- Unique identifier for each user
-    nickname VARCHAR(50) NOT NULL,                          -- User's display name
+    nickname VARCHAR(50) NOT NULL UNIQUE,                   -- User's display name, must be unique
     email VARCHAR(255) NOT NULL UNIQUE,                     -- User's email address, must be unique
     password VARCHAR(255) NOT NULL,                         -- Hashed password
     creation_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP  -- When the user account was created
@@ -14,12 +14,14 @@ CREATE TABLE users (
 
 -- Indexes
 CREATE INDEX users_email_idx ON users(email);              -- Index for faster email lookups
+CREATE INDEX users_nickname_idx ON users(nickname);         -- Index for faster nickname lookups
 
 -- Constraints explained:
 -- 1. Primary Key (id): Ensures each user has a unique identifier
 -- 2. UNIQUE (email): Ensures no duplicate email addresses
--- 3. NOT NULL constraints: Ensures required fields are always provided
--- 4. DEFAULT on creation_date: Automatically sets when user is created
+-- 3. UNIQUE (nickname): Ensures no duplicate nicknames
+-- 4. NOT NULL constraints: Ensures required fields are always provided
+-- 5. DEFAULT on creation_date: Automatically sets when user is created
 
 -- Dependencies:
 -- - Requires UUID extension for gen_random_uuid() function

--- a/migrations/20240322000000000_add_nickname_unique_constraint.sql
+++ b/migrations/20240322000000000_add_nickname_unique_constraint.sql
@@ -1,0 +1,7 @@
+-- Up Migration
+ALTER TABLE users ADD CONSTRAINT users_nickname_unique UNIQUE (nickname);
+CREATE INDEX users_nickname_idx ON users(nickname);
+
+-- Down Migration
+DROP INDEX IF EXISTS users_nickname_idx;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_nickname_unique; 

--- a/src/pages/api/docs.ts
+++ b/src/pages/api/docs.ts
@@ -69,7 +69,20 @@ const apiDocumentation = {
             description: 'Invalid input',
           },
           409: {
-            description: 'Email already registered',
+            description: 'Email or nickname already taken',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    message: {
+                      type: 'string',
+                      enum: ['Email already registered', 'Nickname already taken'],
+                    },
+                  },
+                },
+              },
+            },
           },
           500: {
             description: 'Internal server error',
@@ -91,10 +104,11 @@ const apiDocumentation = {
                 properties: {
                   email: {
                     type: 'string',
-                    format: 'email',
+                    description: 'User email or nickname',
                   },
                   password: {
                     type: 'string',
+                    description: 'User password',
                   },
                 },
               },

--- a/src/pages/api/users/register.ts
+++ b/src/pages/api/users/register.ts
@@ -24,14 +24,19 @@ export default async function handler(
       return res.status(400).json({ message: 'Invalid email format' });
     }
 
-    if (await userService.isEmailTaken(userData.email)) {
-      return res.status(409).json({ message: 'Email already registered' });
+    try {
+      const user = await userService.createUser(userData);
+      delete user.password;
+      res.status(201).json(user);
+    } catch (error) {
+      if (error.message === 'Email already registered') {
+        return res.status(409).json({ message: 'Email already registered' });
+      }
+      if (error.message === 'Nickname already taken') {
+        return res.status(409).json({ message: 'Nickname already taken' });
+      }
+      throw error;
     }
-
-    const user = await userService.createUser(userData);
-    delete user.password;
-    
-    res.status(201).json(user);
   } catch (error) {
     console.error(error);
     res.status(500).json({ message: 'Internal server error' });

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -4,10 +4,24 @@ import bcrypt from 'bcrypt';
 
 export class UserService {
   async createUser(userData: CreateUserDto): Promise<User> {
+    // Check both email and nickname uniqueness
+    const [emailExists, nicknameExists] = await Promise.all([
+      this.isEmailTaken(userData.email),
+      this.isNicknameTaken(userData.nickname)
+    ]);
+
+    if (emailExists) {
+      throw new Error('Email already registered');
+    }
+
+    if (nicknameExists) {
+      throw new Error('Nickname already taken');
+    }
+
     const hashedPassword = await bcrypt.hash(userData.password, 10);
     
     const result = await pool.query(
-      'INSERT INTO users (nickname, email, password) VALUES ($1, $2, $3) RETURNING *',
+      'INSERT INTO users (id, nickname, email, password) VALUES (gen_random_uuid(), $1, $2, $3) RETURNING *',
       [userData.nickname, userData.email, hashedPassword]
     );
     
@@ -24,9 +38,10 @@ export class UserService {
   }
 
   async authenticateUser(credentials: AuthenticateUserDto): Promise<User | null> {
+    // Modified to support both email and nickname authentication
     const result = await pool.query(
-      'SELECT * FROM users WHERE email = $1',
-      [credentials.email]
+      'SELECT * FROM users WHERE email = $1 OR nickname = $1',
+      [credentials.email] // email field now accepts either email or nickname
     );
     
     const user = result.rows[0];
@@ -43,6 +58,14 @@ export class UserService {
     const result = await pool.query(
       'SELECT COUNT(*) FROM users WHERE email = $1',
       [email]
+    );
+    return parseInt(result.rows[0].count) > 0;
+  }
+
+  async isNicknameTaken(nickname: string): Promise<boolean> {
+    const result = await pool.query(
+      'SELECT COUNT(*) FROM users WHERE nickname = $1',
+      [nickname]
     );
     return parseInt(result.rows[0].count) > 0;
   }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -13,6 +13,6 @@ export interface CreateUserDto {
 }
 
 export interface AuthenticateUserDto {
-  email: string;
+  email: string;      // Can be either email or nickname
   password: string;
 } 


### PR DESCRIPTION
After [failure](https://github.com/ebabkin/test-cursor/pull/6/commits/0d03662e0b404a2cc896e64a9b34740ccde63f1e) and making some stricter rules https://github.com/ebabkin/test-cursor/pull/7, we switched to Compose agent and this was the prompt 

Let's change the logic.

User registration should make sure both email and username do not exist
Make authenticate smarter, so that a user could use either username or email

Work across all codebase and follow Contributing Guidelines