### PR TITLE
Switched to JWT tokens for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,55 @@ The API documentation is generated from JSDoc comments in the API route files. T
 1. Add or modify the JSDoc comments in the API route files
 2. The changes will be automatically reflected in the Swagger UI
 3. Make sure to follow the OpenAPI 3.0.0 specification format
+
+## Authentication Configuration
+
+The application uses JWT (JSON Web Tokens) with RS256 algorithm for authentication. This requires a public/private key pair for token signing and verification.
+
+### Generating Keys
+
+1. Generate a private key:
+```bash
+openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
+```
+
+2. Extract the public key:
+```bash
+openssl rsa -pubout -in private.pem -out public.pem
+```
+
+### Environment Configuration
+
+The application expects the following environment variables for JWT authentication:
+
+```env
+# Base64 encoded private key for JWT signing
+JWT_PRIVATE_KEY=<base64-encoded-private-key>
+
+# Base64 encoded public key for JWT verification
+JWT_PUBLIC_KEY=<base64-encoded-public-key>
+```
+
+To set these variables:
+
+1. Convert your PEM files to base64:
+   ```bash
+   # On Unix/Linux/macOS:
+   base64 -i private.pem
+   base64 -i public.pem
+
+   # On Windows PowerShell:
+   [Convert]::ToBase64String([System.IO.File]::ReadAllBytes("private.pem"))
+   [Convert]::ToBase64String([System.IO.File]::ReadAllBytes("public.pem"))
+   ```
+
+2. Add the base64-encoded keys to your environment files:
+   - `.env.local` for local development
+   - `.env.test` for testing environment
+   - Production environment variables should be configured in your deployment platform
+
+### Security Notes
+
+- Keep your private key secure and never commit it to version control
+- Rotate keys periodically for enhanced security
+- Use environment-specific keys for different deployments (development, staging, production)

--- a/database.json
+++ b/database.json
@@ -2,7 +2,7 @@
   "user": "postgres",
   "password": "postgres",
   "host": "localhost",
-  "port": 5432,
+  "port": 5433,
   "database": "postgres",
   "driver": "pg",
   "ssl": false

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -1,14 +1,53 @@
-import { pool } from '../src/config/database';
-import { TextEncoder, TextDecoder } from 'util';
+import { Pool } from 'pg';
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import bcrypt from 'bcrypt';
 
-beforeAll(async () => {
-  // Clean database before tests
-  await pool.query('TRUNCATE TABLE users CASCADE');
-});
+async function globalSetup() {
+  // Load test environment variables
+  dotenv.config({ path: '.env.test' });
 
-afterAll(async () => {
-  await pool.end();
-});
+  const config = {
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '5433'),
+    database: process.env.DB_NAME || 'postgres',
+    user: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASSWORD || 'postgres',
+  };
 
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder; 
+  const pool = new Pool(config);
+
+  try {
+    // Drop existing tables if they exist
+    await pool.query(`
+      DROP TABLE IF EXISTS users CASCADE;
+      DROP TABLE IF EXISTS messages CASCADE;
+    `);
+    console.log('Existing tables dropped successfully');
+
+    // Read schema file
+    const schemaPath = path.join(process.cwd(), 'db', 'schema.sql');
+    const schema = fs.readFileSync(schemaPath, 'utf8');
+
+    // Execute schema
+    await pool.query(schema);
+    console.log('Test database schema initialized successfully');
+
+    // Create test user with bcrypt hashed password
+    const hashedPassword = await bcrypt.hash('password123', 10);
+    await pool.query(
+      'INSERT INTO users (id, nickname, email, password) VALUES (gen_random_uuid(), $1, $2, $3)',
+      ['testuser', 'test@example.com', hashedPassword]
+    );
+    console.log('Test user created successfully');
+
+  } catch (error) {
+    console.error('Error setting up test database:', error);
+    throw error;
+  } finally {
+    await pool.end();
+  }
+}
+
+export default globalSetup; 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.15.10",
         "@mui/material": "^5.15.10",
+        "@types/jsonwebtoken": "^9.0.8",
         "bcrypt": "^5.1.1",
+        "jsonwebtoken": "^9.0.2",
         "next": "14.1.0",
         "next-swagger-doc": "^0.4.0",
         "node-pg-migrate": "^6.2.2",
@@ -32,6 +34,7 @@
         "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.19",
         "@types/testing-library__jest-dom": "^5.14.9",
+        "dotenv": "^16.4.7",
         "dotenv-cli": "^7.4.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -2634,6 +2637,22 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.8.tgz",
+      "integrity": "sha512-7fx54m60nLFUVYlxAB1xpe9CBWX2vSrk50Y6ogRJ1v5xxtba7qXTg5BgYDN5dq+yuQQ9HaVlHJyAAt1/mxryFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.17.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
@@ -3275,6 +3294,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4116,6 +4141,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ejs": {
@@ -6647,6 +6681,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6705,11 +6782,47 @@
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -6723,6 +6836,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {

--- a/package.json
+++ b/package.json
@@ -17,39 +17,42 @@
     "test:e2e:setup": "docker-compose -f docker-compose.test.yml up -d",
     "test:e2e:teardown": "docker-compose -f docker-compose.test.yml down",
     "test:e2e:all": "npm run test:e2e:setup && npm run migrate:test && npm run test:e2e && npm run test:api && npm run test:e2e:teardown",
-    "migrate:test": "dotenv -e .env.test -- npm run migrate:up"    
+    "migrate:test": "dotenv -e .env.test -- npm run migrate:up"
   },
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.10",
     "@mui/material": "^5.15.10",
+    "@types/jsonwebtoken": "^9.0.8",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.2",
     "next": "14.1.0",
     "next-swagger-doc": "^0.4.0",
+    "node-pg-migrate": "^6.2.2",
+    "pg": "^8.11.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "swagger-ui-react": "^5.11.8",
-    "pg": "^8.11.3",
-    "node-pg-migrate": "^6.2.2",
-    "bcrypt": "^5.1.1",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {
-    "ts-jest": "^29.1.2",
+    "@playwright/test": "^1.42.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
-    "@types/testing-library__jest-dom": "^5.14.9",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.19",
     "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.19",
+    "@types/testing-library__jest-dom": "^5.14.9",
+    "dotenv": "^16.4.7",
+    "dotenv-cli": "^7.4.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "node-mocks-http": "^1.14.1",
-    "typescript": "^5.3.3",
-    "@playwright/test": "^1.42.1",
     "supertest": "^6.3.4",
-    "dotenv-cli": "^7.4.1"
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.3.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,26 +1,26 @@
-import { PlaywrightTestConfig } from '@playwright/test';
+import { PlaywrightTestConfig, devices } from '@playwright/test';
+import path from 'path';
 
 const config: PlaywrightTestConfig = {
   testDir: './e2e/playwright',
+  timeout: 30000,
+  globalSetup: path.join(__dirname, './e2e/setup.ts'),
   use: {
     baseURL: 'http://localhost:3000',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
     trace: 'on-first-retry',
-  },
-  webServer: {
-    command: 'npm run dev',
-    port: 3000,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000, // 2 minutes
   },
   projects: [
     {
       name: 'Chrome',
-      use: { browserName: 'chromium' },
-    }
+      use: { ...devices['Desktop Chrome'] },
+    },
   ],
-  timeout: 30000, // 30 seconds per test
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
 };
 
 export default config; 

--- a/src/__tests__/api/messages.test.ts
+++ b/src/__tests__/api/messages.test.ts
@@ -1,11 +1,51 @@
 import { createMocks } from 'node-mocks-http';
 import handler from '../../pages/api/messages';
+import { generateToken } from '../../utils/jwt';
+
+// Mock jwt utils
+jest.mock('../../utils/jwt', () => ({
+  verifyToken: jest.fn().mockReturnValue({
+    sub: 'test-user-id',
+    email: 'test@example.com',
+    nickname: 'testuser'
+  }),
+  extractTokenFromHeader: jest.fn().mockImplementation((header) => {
+    if (!header) {
+      throw new Error('No authorization header');
+    }
+    if (!header.startsWith('Bearer ')) {
+      throw new Error('Invalid authorization header format');
+    }
+    return header.split(' ')[1];
+  })
+}));
 
 describe('/api/messages', () => {
-  it('returns success response for valid message', async () => {
+  const mockValidToken = 'Bearer valid-token';
+
+  it('returns 401 when no auth token is provided', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        message: 'Test message',
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(JSON.parse(res._getData())).toEqual({
+      message: 'Unauthorized'
+    });
+  });
+
+  it('returns success response for valid message with auth token', async () => {
     const testMessage = 'Test message';
     const { req, res } = createMocks({
       method: 'POST',
+      headers: {
+        authorization: mockValidToken
+      },
       body: {
         message: testMessage,
       },
@@ -17,13 +57,16 @@ describe('/api/messages', () => {
     const data = JSON.parse(res._getData());
     expect(data).toHaveProperty('response');
     expect(data.response).toMatch(
-      /^Message from Anonymous accepted, length: \d+ on \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC$/
+      /^Message from testuser accepted, length: \d+ on \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC$/
     );
   });
 
   it('returns 405 for non-POST requests', async () => {
     const { req, res } = createMocks({
       method: 'GET',
+      headers: {
+        authorization: mockValidToken
+      },
     });
 
     await handler(req, res);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,8 +1,9 @@
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
 import { User } from '../types/user';
 
 interface AuthContextType {
   user: User | null;
+  token: string | null;
   login: (email: string, password: string) => Promise<void>;
   signup: (nickname: string, email: string, password: string) => Promise<void>;
   logout: () => void;
@@ -13,6 +14,17 @@ export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+
+  // Load auth state from localStorage on mount
+  useEffect(() => {
+    const savedUser = localStorage.getItem('user');
+    const savedToken = localStorage.getItem('token');
+    if (savedUser && savedToken) {
+      setUser(JSON.parse(savedUser));
+      setToken(savedToken);
+    }
+  }, []);
 
   const login = useCallback(async (email: string, password: string) => {
     const response = await fetch('/api/users/authenticate', {
@@ -26,8 +38,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       throw new Error(error.message || 'Authentication failed');
     }
 
-    const userData = await response.json();
+    const { token: newToken, ...userData } = await response.json();
     setUser(userData);
+    setToken(newToken);
+
+    // Save auth state to localStorage
+    localStorage.setItem('user', JSON.stringify(userData));
+    localStorage.setItem('token', newToken);
   }, []);
 
   const signup = useCallback(async (nickname: string, email: string, password: string) => {
@@ -42,16 +59,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       throw new Error(error.message || 'Registration failed');
     }
 
-    const userData = await response.json();
-    setUser(userData);
-  }, []);
+    // After successful registration, log in automatically
+    await login(email, password);
+  }, [login]);
 
   const logout = useCallback(() => {
     setUser(null);
+    setToken(null);
+    localStorage.removeItem('user');
+    localStorage.removeItem('token');
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, login, signup, logout, isAuthenticated: !!user }}>
+    <AuthContext.Provider value={{ 
+      user, 
+      token,
+      login, 
+      signup, 
+      logout, 
+      isAuthenticated: !!user && !!token 
+    }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,37 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { verifyToken, extractTokenFromHeader } from '../utils/jwt';
+
+export interface AuthenticatedRequest extends NextApiRequest {
+  user?: {
+    id: string;
+    email: string;
+    nickname: string;
+  };
+}
+
+type NextApiHandler = (req: AuthenticatedRequest, res: NextApiResponse) => Promise<void>;
+
+export const withAuth = (handler: NextApiHandler) => {
+  return async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    try {
+      // Skip auth for OPTIONS requests (CORS preflight)
+      if (req.method === 'OPTIONS') {
+        return handler(req, res);
+      }
+
+      const token = extractTokenFromHeader(req.headers.authorization);
+      const decoded = verifyToken(token);
+
+      // Add user info to request
+      req.user = {
+        id: decoded.sub as string,
+        email: decoded.email as string,
+        nickname: decoded.nickname as string
+      };
+
+      return handler(req, res);
+    } catch (error) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+  };
+}; 

--- a/src/pages/api/messages.ts
+++ b/src/pages/api/messages.ts
@@ -1,11 +1,14 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
+import { withAuth, AuthenticatedRequest } from '../../middleware/auth';
 
 /**
  * @swagger
  * /api/messages:
  *   post:
  *     summary: Send a message and get a response
- *     description: Accepts a message and returns a confirmation with timestamp
+ *     description: Accepts a message and returns a confirmation with timestamp. Requires authentication.
+ *     security:
+ *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -27,16 +30,18 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  *                 response:
  *                   type: string
  *                   description: Confirmation message with timestamp
+ *       401:
+ *         description: Unauthorized - valid authentication token required
  *       405:
  *         description: Method not allowed
  */
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const { message, user } = req.body;
-  const nickname = user?.nickname || 'Anonymous';
+  const { message } = req.body;
+  const nickname = req.user?.nickname || 'Anonymous';
 
   // Log message to stdout with user info
   console.log(`Received message from ${nickname}:`, message);
@@ -59,4 +64,6 @@ function formatDate(date: Date): string {
   const seconds = String(date.getUTCSeconds()).padStart(2, '0');
   
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
-} 
+}
+
+export default withAuth(handler); 

--- a/src/pages/api/users/authenticate.ts
+++ b/src/pages/api/users/authenticate.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { UserService } from '../../../services/userService';
 import { AuthenticateUserDto } from '../../../types/user';
+import { generateToken } from '../../../utils/jwt';
 
 const userService = new UserService();
 
@@ -25,7 +26,15 @@ export default async function handler(
       return res.status(401).json({ message: 'Invalid credentials' });
     }
 
-    res.status(200).json(user);
+    // Generate JWT token
+    const token = generateToken(user);
+
+    // Return user info and token
+    const { password, ...userWithoutPassword } = user;
+    res.status(200).json({
+      ...userWithoutPassword,
+      token
+    });
   } catch (error) {
     console.error(error);
     res.status(500).json({ message: 'Internal server error' });

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,67 @@
+import jwt from 'jsonwebtoken';
+import { User } from '../types/user';
+
+const decodeBase64 = (base64String: string): string => {
+  return Buffer.from(base64String, 'base64').toString('utf-8');
+};
+
+const getPrivateKey = () => {
+  const key = process.env.JWT_PRIVATE_KEY;
+  if (!key) {
+    throw new Error('JWT_PRIVATE_KEY environment variable is not set');
+  }
+  return decodeBase64(key);
+};
+
+const getPublicKey = () => {
+  const key = process.env.JWT_PUBLIC_KEY;
+  if (!key) {
+    throw new Error('JWT_PUBLIC_KEY environment variable is not set');
+  }
+  return decodeBase64(key);
+};
+
+export const generateToken = (user: User): string => {
+  const privateKey = getPrivateKey();
+  
+  // Create token payload
+  const payload = {
+    sub: user.id,
+    email: user.email,
+    nickname: user.nickname
+  };
+
+  // Sign token with private key using RS256 algorithm
+  return jwt.sign(payload, privateKey, {
+    algorithm: 'RS256',
+    expiresIn: '24h' // Token expires in 24 hours
+  });
+};
+
+export const verifyToken = (token: string): jwt.JwtPayload => {
+  const publicKey = getPublicKey();
+  
+  try {
+    // Verify token with public key
+    const decoded = jwt.verify(token, publicKey, {
+      algorithms: ['RS256']
+    });
+    
+    return decoded as jwt.JwtPayload;
+  } catch (error) {
+    throw new Error('Invalid token');
+  }
+};
+
+export const extractTokenFromHeader = (authHeader?: string): string => {
+  if (!authHeader) {
+    throw new Error('No authorization header');
+  }
+
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    throw new Error('Invalid authorization header format');
+  }
+
+  return parts[1];
+}; 


### PR DESCRIPTION
Prompt

> Let's change backend-frontend authentication to use JWT token. 
> 
> For simplicity the current backend needs to issue the tokens and then check those, levelraging the private/public key system. 
> 
> Private/public keys should be parameterised so could be overriden per environment. Make a section in Readme explaining how that works. 
> 
> Let's deprecate the ability to send messages non-authenticated and requite authentication at the API level. 
> 
> Keep UI as is for now. 
> 
> Put a special attention to the api tests and end2end tests : those need to be changed in a way so those would continue working. 
> 
> Follow contributing guidelines. @CONTRIBUTING.md 
> @Codebase