### PR TITLE
Tests simplified, cursor can now run tests itself

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,7 +4,7 @@
 
 -- Users Table
 -- Stores user account information
-CREATE TABLE users (
+CREATE TABLE IF NOT EXISTS users (
     id UUID PRIMARY KEY,                                    -- Unique identifier for each user
     nickname VARCHAR(50) NOT NULL UNIQUE,                   -- User's display name, must be unique
     email VARCHAR(255) NOT NULL UNIQUE,                     -- User's email address, must be unique
@@ -13,8 +13,21 @@ CREATE TABLE users (
 );
 
 -- Indexes
-CREATE INDEX users_email_idx ON users(email);              -- Index for faster email lookups
-CREATE INDEX users_nickname_idx ON users(nickname);         -- Index for faster nickname lookups
+CREATE INDEX IF NOT EXISTS users_email_idx ON users(email);              -- Index for faster email lookups
+CREATE INDEX IF NOT EXISTS users_nickname_idx ON users(nickname);         -- Index for faster nickname lookups
+
+-- Messages Table
+-- Stores chat messages
+CREATE TABLE IF NOT EXISTS messages (
+    id UUID PRIMARY KEY,                                    -- Unique identifier for each message
+    user_id UUID NOT NULL REFERENCES users(id),            -- Foreign key to users table
+    content TEXT NOT NULL,                                 -- Message content
+    creation_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP  -- When the message was sent
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS messages_user_id_idx ON messages(user_id);    -- Index for faster user message lookups
+CREATE INDEX IF NOT EXISTS messages_creation_date_idx ON messages(creation_date);  -- Index for message ordering
 
 -- Constraints explained:
 -- 1. Primary Key (id): Ensures each user has a unique identifier
@@ -22,7 +35,8 @@ CREATE INDEX users_nickname_idx ON users(nickname);         -- Index for faster 
 -- 3. UNIQUE (nickname): Ensures no duplicate nicknames
 -- 4. NOT NULL constraints: Ensures required fields are always provided
 -- 5. DEFAULT on creation_date: Automatically sets when user is created
+-- 6. REFERENCES users(id): Ensures message author exists
 
 -- Dependencies:
 -- - Requires UUID extension for gen_random_uuid() function
--- - Used by: Authentication system, User profile system 
+-- - Used by: Authentication system, User profile system, Chat system 

--- a/e2e/api/users.test.ts
+++ b/e2e/api/users.test.ts
@@ -1,9 +1,26 @@
 import request from 'supertest';
 import { pool } from '../../src/config/database';
+import { API_TEST_USER } from '../jest.setup';
 
 const BASE_URL = 'http://localhost:3000';
 
 describe('User API E2E', () => {
+    // Add server health check test first
+    it('should verify server is running', async () => {
+        try {
+            await request(BASE_URL)
+                .get('/api/health')
+                .timeout(5000); // 5 second timeout
+        } catch (error) {
+            console.error('\x1b[31m%s\x1b[0m', `
+🚨 SERVER NOT RUNNING 🚨
+Please ensure the server is running on ${BASE_URL} before running tests.
+You can start the server using 'npm run dev'
+            `);
+            throw new Error('Server is not running');
+        }
+    });
+
     beforeAll(async () => {
         // Verify database connection
         try {
@@ -16,62 +33,64 @@ describe('User API E2E', () => {
    });
 
     beforeEach(async () => {
-    await pool.query('TRUNCATE TABLE users CASCADE');
-  });
+        // Note: We specifically delete only test-related data instead of truncating the whole table
+        // to avoid affecting production data during tests
+        await pool.query('DELETE FROM messages WHERE user_id IN (SELECT id FROM users WHERE email = $1)', [API_TEST_USER.email]);
+        await pool.query('DELETE FROM users WHERE email = $1', [API_TEST_USER.email]);
+    });
 
+    it('should register and authenticate user', async () => {
+        try {
+            // Register user
+            const registerRes = await request(BASE_URL)
+                .post('/api/users/register')
+                .send({
+                    nickname: API_TEST_USER.nickname,
+                    email: API_TEST_USER.email,
+                    password: API_TEST_USER.password
+                });
 
-  it('should register and authenticate user', async () => {
-    try {
-      // Register user
-      const registerRes = await request(BASE_URL)
-        .post('/api/users/register')
-        .send({
-          nickname: 'testuser',
-          email: 'test@example.com',
-          password: 'password123'
-        });
+            console.log('Register response:', registerRes.status, registerRes.body);
+            expect(registerRes.status).toBe(201);
+            expect(registerRes.body).toHaveProperty('id');
+            
+            // Authenticate user
+            const authRes = await request(BASE_URL)
+                .post('/api/users/authenticate')
+                .send({
+                    email: API_TEST_USER.email,
+                    password: API_TEST_USER.password
+                });
 
-      console.log('Register response:', registerRes.status, registerRes.body);
-      expect(registerRes.status).toBe(201);
-      expect(registerRes.body).toHaveProperty('id');
-      
-      // Authenticate user
-      const authRes = await request(BASE_URL)
-        .post('/api/users/authenticate')
-        .send({
-          email: 'test@example.com',
-          password: 'password123'
-        });
+            console.log('Auth response:', authRes.status, authRes.body);
+            expect(authRes.status).toBe(200);
+            expect(authRes.body.email).toBe(API_TEST_USER.email);
+        } catch (error) {
+            console.error('Test failed:', error);
+            throw error;
+        }
+    });
 
-      console.log('Auth response:', authRes.status, authRes.body);
-      expect(authRes.status).toBe(200);
-      expect(authRes.body.email).toBe('test@example.com');
-    } catch (error) {
-      console.error('Test failed:', error);
-      throw error;
-    }
-  });
+    it('should prevent duplicate email registration', async () => {
+        // Register first user
+        await request(BASE_URL)
+            .post('/api/users/register')
+            .send({
+                nickname: API_TEST_USER.nickname,
+                email: API_TEST_USER.email,
+                password: API_TEST_USER.password
+            });
 
-  it('should prevent duplicate email registration', async () => {
-    // Register first user
-    await request(BASE_URL)
-      .post('/api/users/register')
-      .send({
-        nickname: 'user1',
-        email: 'test@example.com',
-        password: 'password123'
-      });
+        // Try to register with same email
+        const duplicateRes = await request(BASE_URL)
+            .post('/api/users/register')
+            .send({
+                nickname: 'another_user',
+                email: API_TEST_USER.email,
+                password: API_TEST_USER.password
+            });
 
-    // Try to register with same email
-    const duplicateRes = await request(BASE_URL)
-      .post('/api/users/register')
-      .send({
-        nickname: 'user2',
-        email: 'test@example.com',
-        password: 'password123'
-      });
-
-    expect(duplicateRes.status).toBe(409);
-    expect(duplicateRes.body.message).toBe('Email already registered');
-  });
+        expect(duplicateRes.status).toBe(409);
+        expect(duplicateRes.body.message).toBe('Email already registered');
+    });
 }); 

--- a/e2e/jest.setup.ts
+++ b/e2e/jest.setup.ts
@@ -1,11 +1,26 @@
+/**
+ * Jest setup for API E2E tests
+ * This file configures the test environment for API testing
+ */
+
 import { TextEncoder, TextDecoder } from 'util';
 import { pool } from '../src/config/database';
 
+// Required for JWT token handling in tests
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
+// Constants for test users - keep in sync with setup.ts
+export const API_TEST_USER = {
+  email: 'apitest@example.com',
+  nickname: 'apitest',
+  password: 'password123'
+};
+
 beforeAll(async () => {
-  await pool.query('TRUNCATE TABLE users CASCADE');
+  // Note: We specifically delete only test-related data instead of truncating the whole table
+  // to avoid affecting production data during tests
+  await pool.query('DELETE FROM users WHERE email = $1', [API_TEST_USER.email]);
 });
 
 afterAll(async () => {

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -1,8 +1,26 @@
+/**
+ * Global setup for both API and UI E2E tests
+ * This file initializes the test database and creates necessary test users
+ */
+
 import { Pool } from 'pg';
 import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
 import bcrypt from 'bcrypt';
+
+// Test user constants - keep in sync with jest.setup.ts and playwright tests
+const API_TEST_USER = {
+  email: 'apitest@example.com',
+  nickname: 'apitest',
+  password: 'password123'
+};
+
+const UI_TEST_USER = {
+  email: 'uitest@example.com',
+  nickname: 'uitest',
+  password: 'password123'
+};
 
 async function globalSetup() {
   // Load test environment variables
@@ -19,28 +37,36 @@ async function globalSetup() {
   const pool = new Pool(config);
 
   try {
-    // Drop existing tables if they exist
-    await pool.query(`
-      DROP TABLE IF EXISTS users CASCADE;
-      DROP TABLE IF EXISTS messages CASCADE;
-    `);
-    console.log('Existing tables dropped successfully');
+    // Note: Instead of dropping all tables, we now only remove test-specific data
+    // This is safer for running tests against shared databases
+    await pool.query('DELETE FROM users WHERE email IN ($1, $2)', 
+      [API_TEST_USER.email, UI_TEST_USER.email]);
+    console.log('Existing test users cleaned up successfully');
 
-    // Read schema file
+    // Read and execute schema (tables will only be created if they don't exist)
     const schemaPath = path.join(process.cwd(), 'db', 'schema.sql');
     const schema = fs.readFileSync(schemaPath, 'utf8');
 
     // Execute schema
     await pool.query(schema);
-    console.log('Test database schema initialized successfully');
+    console.log('Test database schema verified successfully');
 
-    // Create test user with bcrypt hashed password
-    const hashedPassword = await bcrypt.hash('password123', 10);
+    // Create test users with bcrypt hashed password
+    const hashedPassword = await bcrypt.hash(API_TEST_USER.password, 10);
+    
+    // Create API test user
     await pool.query(
       'INSERT INTO users (id, nickname, email, password) VALUES (gen_random_uuid(), $1, $2, $3)',
-      ['testuser', 'test@example.com', hashedPassword]
+      [API_TEST_USER.nickname, API_TEST_USER.email, hashedPassword]
     );
-    console.log('Test user created successfully');
+
+    // Create UI test user
+    await pool.query(
+      'INSERT INTO users (id, nickname, email, password) VALUES (gen_random_uuid(), $1, $2, $3)',
+      [UI_TEST_USER.nickname, UI_TEST_USER.email, hashedPassword]
+    );
+    
+    console.log('Test users created successfully');
 
   } catch (error) {
     console.error('Error setting up test database:', error);

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  res.status(200).json({ status: 'ok' });
+} 


### PR DESCRIPTION
Prompt

> Let's make API and UI tests a bit less destructive. 
> 
> 1. Tests now truncate or delete users table (and messages). Let's change that to deleting the user used by the text pack. 
> E.g. introduce APItest and UItest users with appropriate emails and replace truncate/delete with deleting of that user (and messages of that user beforehand, if necessary)
> When doing that, leave a comment that we should not truncate/delete whole table so you would not forget in future. 
> 
> 2. There are a few config files in e2e folder; 
> make a comment in the beginning of each one if that is relevant for API or UI tests 

and a few followups