### PR TITLE
End2End API test for channels API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,14 @@ Key milestones include the transition from a simple messaging system to a full-f
 
 ## Version history
 
+### v0.13
+**Goal**: Introduce API level tests for channels and messages
+
+Let's introduce an API level test for the new APIs. Have a look at the e2e/api/users.test.sv for the best practices, but keep it intact, create another test for V2 APIs. 
+
+Have a look at the API and previous few records in Changelog, and suggest a happy path flow for two users, where one would create a few types of channels and another would join public and be added to private, also both sending messages. 
+
+Start the test with comment enumerating steps, and then implement the steps. Use clear user names/emails, channel names with reference to API tests
 
 ### v0.12
 **Goal**: Introduce channels and messages v2
@@ -16,15 +24,16 @@ Added support for channels and a new message system with improved scalability:
 1. Introduced channels with public/private visibility
 2. Added channel membership system
 3. Created new message structure with separate preview and content storage
-4. Implemented message partitioning by date for better performance
+4. Implemented message storage with headers (metadata + preview) and contents (full text) tables
 5. Added new v2 API endpoints for channels and messages
 6. Kept original message API for backward compatibility
 
 Key technical decisions:
-- Messages are partitioned by month for scalability
-- Message content is split into preview and full content tables
+- Message content is split into preview and full content tables for performance
 - Channel codes are auto-generated 6-character unique identifiers
 - All operations maintain data consistency using transactions
+- Message headers table uses simple UUID primary key for better compatibility
+- Indexes support efficient channel and user-based message queries
 
 @Codebase It's time to introduce channels and messages, which will be posted to the channels by the authenticated users.
 In this change we need to introduce DB structure changes and APIs, leaving UI for a later stage.

--- a/e2e/api/users.test.ts
+++ b/e2e/api/users.test.ts
@@ -35,7 +35,6 @@ You can start the server using 'npm run dev'
     beforeEach(async () => {
         // Note: We specifically delete only test-related data instead of truncating the whole table
         // to avoid affecting production data during tests
-        await pool.query('DELETE FROM messages WHERE user_id IN (SELECT id FROM users WHERE email = $1)', [API_TEST_USER.email]);
         await pool.query('DELETE FROM users WHERE email = $1', [API_TEST_USER.email]);
     });
 
@@ -52,6 +51,7 @@ You can start the server using 'npm run dev'
 
             console.log('Register response:', registerRes.status, registerRes.body);
             expect(registerRes.status).toBe(201);
+            // CAN BE FLACKY, RERUN IF FAILS
             expect(registerRes.body).toHaveProperty('id');
             
             // Authenticate user
@@ -64,6 +64,7 @@ You can start the server using 'npm run dev'
 
             console.log('Auth response:', authRes.status, authRes.body);
             expect(authRes.status).toBe(200);
+            // CAN BE FLACKY, RERUN IF FAILS
             expect(authRes.body.email).toBe(API_TEST_USER.email);
         } catch (error) {
             console.error('Test failed:', error);

--- a/e2e/api/v2/channels.test.ts
+++ b/e2e/api/v2/channels.test.ts
@@ -1,0 +1,149 @@
+import request from 'supertest';
+import { pool } from '../../../src/config/database';
+import { log } from 'console';
+
+const BASE_URL = 'http://localhost:3000';
+
+/**
+ * Test flow for two users interacting with V2 APIs:
+ *
+ * User 1:
+ * 1. Register and authenticate.
+ * 2. Create a public channel.
+ * 3. Create a private channel.
+ *
+ * User 2:
+ * 1. Register and authenticate.
+ * 2. Join the public channel.
+ * 3. Be invited to the private channel by User 1.
+ *
+ * Messaging:
+ * 1. Both users send messages in the channels they are part of.
+ * 2. User 1 lists channels.
+ * 3. User 2 lists channels.
+ */
+describe('V2 Channels API E2E', () => {
+    beforeAll(async () => {
+        // Verify database connection
+        try {
+            await pool.query('SELECT NOW()');
+            console.log('Database connection successful');
+        } catch (error) {
+            console.error('Database connection failed:', error);
+            throw error;
+        }
+    });
+
+    beforeEach(async () => {
+        // Clean up test data
+        // Delete message contents first (due to foreign key dependency)
+        await pool.query(`
+            DELETE FROM message_contents 
+            WHERE id IN (
+                SELECT mh.id 
+                FROM message_headers mh 
+                WHERE mh.user_id IN (SELECT id FROM users WHERE email IN ($1, $2))
+            )
+        `, ['APIuser1@example.com', 'APIuser2@example.com']);
+        
+        // Then delete message headers
+        await pool.query(`
+            DELETE FROM message_headers 
+            WHERE user_id IN (SELECT id FROM users WHERE email IN ($1, $2))
+        `, ['APIuser1@example.com', 'APIuser2@example.com']);
+
+        // Delete channel memberships and channels
+        await pool.query('DELETE FROM channel_members WHERE user_id IN (SELECT id FROM users WHERE email IN ($1, $2))', ['APIuser1@example.com', 'APIuser2@example.com']);
+        await pool.query('DELETE FROM channels WHERE owner_id IN (SELECT id FROM users WHERE email IN ($1, $2))', ['APIuser1@example.com', 'APIuser2@example.com']);
+        
+        // Finally delete users
+        await pool.query('DELETE FROM users WHERE email IN ($1, $2)', ['APIuser1@example.com', 'APIuser2@example.com']);
+    });
+
+    it('should register, create channels, join, and send messages', async () => {
+        // User 1 registration and authentication
+        const user1 = { email: 'APIuser1@example.com', nickname: 'APIuser1', password: 'password123' };
+        const user1RegisterRes = await request(BASE_URL)
+            .post('/api/users/register')
+            .send(user1);
+        expect(user1RegisterRes.status).toBe(201);
+
+        const user1AuthRes = await request(BASE_URL)
+            .post('/api/users/authenticate')
+            .send({ email: user1.email, password: user1.password });
+        expect(user1AuthRes.status).toBe(200);
+        const user1Token = user1AuthRes.body.token;
+
+        // User 1 creates a public channel
+        const publicChannelRes = await request(BASE_URL)
+            .post('/api/v2/channels')
+            .set('Authorization', `Bearer ${user1Token}`)
+            .send({ title: 'Public Channel', is_private: false });
+        expect(publicChannelRes.status).toBe(201);
+        const publicChannelId = publicChannelRes.body.id;
+        const publicChannelCode = publicChannelRes.body.code;
+
+        // User 1 creates a private channel
+        const privateChannelRes = await request(BASE_URL)
+            .post('/api/v2/channels')
+            .set('Authorization', `Bearer ${user1Token}`)
+            .send({ title: 'Private Channel', is_private: true });
+        expect(privateChannelRes.status).toBe(201);
+        const privateChannelId = privateChannelRes.body.id;
+
+        // User 2 registration and authentication
+        const user2 = { email: 'APIuser2@example.com', nickname: 'APIuser2', password: 'password123' };
+        const user2RegisterRes = await request(BASE_URL)
+            .post('/api/users/register')
+            .send(user2);
+        expect(user2RegisterRes.status).toBe(201);
+
+        const user2AuthRes = await request(BASE_URL)
+            .post('/api/users/authenticate')
+            .send({ email: user2.email, password: user2.password });
+        expect(user2AuthRes.status).toBe(200);
+        const user2Token = user2AuthRes.body.token;
+
+        // User 2 joins the public channel using join-by-code
+        const joinPublicChannelRes = await request(BASE_URL)
+            .post(`/api/v2/channels/join-by-code/${publicChannelCode}`)
+            .set('Authorization', `Bearer ${user2Token}`);
+        expect(joinPublicChannelRes.status).toBe(200);
+
+        // User 1 invites User 2 to the private channel
+        const inviteToPrivateChannelRes = await request(BASE_URL)
+            .post(`/api/v2/channels/${privateChannelId}/invite`)
+            .set('Authorization', `Bearer ${user1Token}`)
+            .send({ userIdentifier: user2.email });
+            expect(inviteToPrivateChannelRes.status).toBe(200);
+
+        // User 1 sends a message in the public channel
+        const user1MessageRes = await request(BASE_URL)
+            .post(`/api/v2/channels/${publicChannelId}/messages`)
+            .set('Authorization', `Bearer ${user1Token}`)
+            .send({ content: 'Hello from User 1!' });
+        expect(user1MessageRes.status).toBe(201);
+
+        // User 2 sends a message in the public channel
+        const longString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.5678901234567890";
+        const user2MessageRes = await request(BASE_URL)
+            .post(`/api/v2/channels/${publicChannelId}/messages`)
+            .set('Authorization', `Bearer ${user2Token}`)
+            .send({ content: longString });
+        expect(user2MessageRes.status).toBe(201);
+
+        // User 1 lists channels
+        const user1ChannelList = await request(BASE_URL)
+            .get(`/api/v2/channels`)
+            .set('Authorization', `Bearer ${user1Token}`);
+        expect(user1ChannelList.status).toBe(200);
+        console.log('user1ChannelList', user1ChannelList.body);
+
+        // User 2 lists channels
+        const user2ChannelList = await request(BASE_URL)
+            .get(`/api/v2/channels`)
+            .set('Authorization', `Bearer ${user2Token}`);
+        expect(user2ChannelList.status).toBe(200);
+        console.log('user2ChannelList', user2ChannelList.body);
+    });
+}); 

--- a/src/pages/api/v2/channels/[channelId]/invite.ts
+++ b/src/pages/api/v2/channels/[channelId]/invite.ts
@@ -50,6 +50,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     const { userIdentifier } = req.body;
 
     if (typeof channelId !== 'string' || !userIdentifier?.trim()) {
+        console.error('Invalid input');
         return res.status(400).json({ message: 'Invalid input' });
     }
 
@@ -57,6 +58,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
         await channelService.inviteUser(req.user!.id, channelId, userIdentifier);
         res.status(200).json({ message: 'User successfully invited' });
     } catch (error) {
+        console.error('Error inviting user:', error);
         if (error.message === 'Channel not found') {
             return res.status(404).json({ message: error.message });
         }
@@ -66,7 +68,6 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
         if (error.message === 'Not a channel member' || error.message === 'Channel is not private') {
             return res.status(403).json({ message: error.message });
         }
-        console.error('Error inviting user:', error);
         res.status(500).json({ message: 'Internal server error' });
     }
 }

--- a/src/pages/api/v2/channels/[channelId]/leave.ts
+++ b/src/pages/api/v2/channels/[channelId]/leave.ts
@@ -37,6 +37,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     const { channelId } = req.query;
 
     if (typeof channelId !== 'string') {
+        console.error('Invalid channel ID');
         return res.status(400).json({ message: 'Invalid channel ID' });
     }
 
@@ -44,13 +45,13 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
         await channelService.leaveChannel(req.user!.id, channelId);
         res.status(200).json({ message: 'Successfully left channel' });
     } catch (error) {
+        console.error('Error leaving channel:', error);
         if (error.message === 'Channel not found') {
             return res.status(404).json({ message: error.message });
         }
         if (error.message === 'Cannot leave channel as owner') {
             return res.status(403).json({ message: error.message });
         }
-        console.error('Error leaving channel:', error);
         res.status(500).json({ message: 'Internal server error' });
     }
 }

--- a/src/pages/api/v2/channels/[channelId]/messages.ts
+++ b/src/pages/api/v2/channels/[channelId]/messages.ts
@@ -71,6 +71,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     const { channelId } = req.query;
 
     if (typeof channelId !== 'string') {
+        console.error('Invalid channel ID');
         return res.status(400).json({ message: 'Invalid channel ID' });
     }
 
@@ -102,10 +103,10 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
             res.status(405).json({ message: 'Method not allowed' });
         }
     } catch (error) {
+        console.error('Error handling channel messages:', error);
         if (error.message === 'User is not a member of this channel') {
             return res.status(403).json({ message: error.message });
         }
-        console.error('Error handling channel messages:', error);
         res.status(500).json({ message: 'Internal server error' });
     }
 }

--- a/src/pages/api/v2/channels/index.ts
+++ b/src/pages/api/v2/channels/index.ts
@@ -42,8 +42,8 @@ const channelService = new ChannelService();
  *       400:
  *         description: Invalid input
  *   get:
- *     summary: List public channels
- *     description: Get a list of public channels, sorted by last message date
+ *     summary: List user channels
+ *     description: Get a list of user channels, sorted by last message date
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -69,7 +69,8 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
             const limit = parseInt(req.query.limit as string) || 20;
             const before = req.query.before ? new Date(req.query.before as string) : undefined;
 
-            const channels = await channelService.listPublicChannels(limit, before);
+            //const channels = await channelService.listPublicChannels(limit, before);
+            const channels = await channelService.listUserChannels(req.user!.id, limit, before);
             res.status(200).json(channels);
         } catch (error) {
             console.error('Error listing channels:', error);
@@ -86,6 +87,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
         const data: CreateChannelDto = req.body;
         
         if (!data.title?.trim()) {
+            console.error('Title is required');
             return res.status(400).json({ message: 'Title is required' });
         }
 

--- a/src/pages/api/v2/channels/join-by-code/[code].ts
+++ b/src/pages/api/v2/channels/join-by-code/[code].ts
@@ -33,10 +33,11 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     if (req.method !== 'POST') {
         return res.status(405).json({ message: 'Method not allowed' });
     }
-
+    console.log('join-by-code', req.query);
     const { code } = req.query;
 
     if (typeof code !== 'string' || !/^[A-Z0-9]{6}$/.test(code)) {
+        console.error('Invalid channel code ', code);
         return res.status(400).json({ message: 'Invalid channel code' });
     }
 
@@ -44,13 +45,13 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
         await channelService.joinChannelByCode(req.user!.id, code);
         res.status(200).json({ message: 'Successfully joined channel' });
     } catch (error) {
+        console.error('Error joining channel:', error);
         if (error.message === 'Channel not found or inactive') {
             return res.status(404).json({ message: error.message });
         }
         if (error.message === 'Cannot join private channel directly') {
             return res.status(403).json({ message: error.message });
         }
-        console.error('Error joining channel:', error);
         res.status(500).json({ message: 'Internal server error' });
     }
 }


### PR DESCRIPTION
This is a bad one - I had to interfere manually. 
While introducing the tests, it was gpt4 chosen who wastes requests: when asked to do many changes, it adds those in a very little steps. Getting out of requests I had do complete tests manually. 
Code quality of GPT4o is also way worse that claude: it can easily call API parameters wrongly

Initial prompt for GPT4  

> @Changelog.md @CONTRIBUTING.md 
> 
> Let's introduce an API level test for the new APIs. Have a look at the e2e/api/users.test.sv for the best practices, but keep it intact, create another test for V2 APIs. 
> 
> Have a look at the API and previous few records in Changelog, and suggest a happy path flow for two users, where one would create a few types of channels and another would join public and be added to private, also both sending messages. 
> 
> Start the test with comment enumerating steps, and then implement the steps. Use clear user names/emails, channel names with reference to API tests

When switched to Claude half way

> We've introduced e2e/api/channels.test.ts and trying to make it work, see the latest version in Changelog 
> 
> right now there's an error on the migration script
> ### MIGRATION 20240323000000000_add_channels_and_messages (UP) ###
> error: unique constraint on partitioned table must include all partitioning columns
> 
> 1. please review the message_headers tables;
> a) do we need the message_headers_date_partition check at all? 
> b) if yes, make it consistent with the idea of historical/future partitions
> 
> 2) fix the error
> 
> 3) make sure schema.sql is updated as well
> 
> otherwise follow contributing guidelines