### PR TITLE
The app UI was reworked to support channels.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,19 @@ Key milestones include the transition from a simple messaging system to a full-f
 
 ## Version history
 
+### v0.14
+**Goal**: Update UI to use v2 channel and messages API
+
+Updating the UI to support channels while keeping the existing architecture:
+1. Split main screen into channels list and messages panel
+2. Add channel creation and join functionality
+3. Implement channel message viewing and sending
+4. Support channel management (add user, leave channel)
+5. Enable deep linking to specific channels
+6. Keep existing authentication UI and mechanisms
+
+Note: Existing UI tests are preserved for now and will be updated in a separate change.
+
 ### v0.13
 **Goal**: Introduce API level tests for channels and messages
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "test": "jest",
     "test:watch": "jest --watch",
+    "clear_jest": "jest --clearCache",
     "migrate": "node-pg-migrate --config-file database.json --migrations-dir migrations",
     "migrate:up": "node-pg-migrate --config-file database.json --migrations-dir migrations up",
     "migrate:down": "node-pg-migrate --config-file database.json --migrations-dir migrations down",

--- a/src/__tests__/api/channels.index.test.ts
+++ b/src/__tests__/api/channels.index.test.ts
@@ -1,0 +1,79 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../pages/api/v2/channels/[channelId]/index';
+import { pool } from '../../config/database';
+import { generateToken } from '../../utils/jwt';
+import { generateChannelCode } from '../../utils/channel';
+import { log } from 'console';
+
+jest.mock('../../config/database', () => ({
+  pool: {
+    query: jest.fn(),
+    connect: jest.fn().mockResolvedValue({
+      query: jest.fn(),
+      release: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('../../utils/jwt', () => ({
+  generateToken: jest.fn().mockReturnValue('mock-jwt-token'),
+}));
+
+jest.mock('../../middleware/auth', () => ({
+  withAuth: (handler: any) => (req: any, res: any) => {
+    req.user = { id: 'mock-user-id' };
+    return handler(req, res);
+  },
+}));
+
+jest.mock('../../utils/channel', () => ({
+  generateChannelCode: jest.fn().mockResolvedValue('ABC123'),
+}));
+
+describe('Channel API Endpoints', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/v2/channels/:channelId', () => {
+    it('should get channel info successfully', async () => {
+      (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ id: '1' }] }) // Mock member check
+      .mockResolvedValueOnce({
+            rows: [{
+              id: 'mock-channel-id',
+              title: 'Public Channel',
+              description: 'A public channel',
+              is_private: false,
+              region_id: 'DEFAULT',
+              code: 'ABC123',
+              owner_id: 'mock-user-id',
+            }],    
+       });
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: { channelId: 'mock-channel-id' },
+      });
+
+      req.user = { id: 'mock-user-id' };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual(
+        {
+          id: 'mock-channel-id',
+          title: 'Public Channel',
+          description: 'A public channel',
+          is_private: false,
+          region_id: 'DEFAULT',
+          code: 'ABC123',
+          owner_id: 'mock-user-id',
+        },
+      );
+    });
+  });
+
+
+}); 

--- a/src/__tests__/api/channels.test.ts
+++ b/src/__tests__/api/channels.test.ts
@@ -3,6 +3,7 @@ import handler from '../../pages/api/v2/channels';
 import { pool } from '../../config/database';
 import { generateToken } from '../../utils/jwt';
 import { generateChannelCode } from '../../utils/channel';
+import { log } from 'console';
 
 jest.mock('../../config/database', () => ({
   pool: {

--- a/src/components/ChannelList.tsx
+++ b/src/components/ChannelList.tsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from 'react';
+import { List, ListItem, ListItemText, Button, Box, Typography } from '@mui/material';
+import { Channel } from '../types/channel';
+import CreateChannelModal from './modals/CreateChannelModal';
+import JoinChannelModal from './modals/JoinChannelModal';
+import { useAuth } from '../contexts/AuthContext';
+import { useRouter } from 'next/router';
+
+export default function ChannelList() {
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [joinModalOpen, setJoinModalOpen] = useState(false);
+  const { token, isAuthenticated } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      fetchChannels();
+    }
+  }, [isAuthenticated]);
+
+  const fetchChannels = async () => {
+    try {
+      const response = await fetch('/api/v2/channels', {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setChannels(data);
+      }
+    } catch (error) {
+      console.error('Error fetching channels:', error);
+    }
+  };
+
+  const handleChannelClick = (channelId: string) => {
+    router.push(`/channels/${channelId}`);
+  };
+
+  if (!isAuthenticated) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography color="text.secondary">
+          Please log in to view channels
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Box sx={{ p: 1, display: 'flex', gap: 1 }}>
+        <Button 
+          variant="contained" 
+          onClick={() => setCreateModalOpen(true)}
+          size="small"
+        >
+          Create Channel
+        </Button>
+        <Button 
+          variant="outlined" 
+          onClick={() => setJoinModalOpen(true)}
+          size="small"
+        >
+          Join Channel
+        </Button>
+      </Box>
+      
+      <List sx={{ flex: 1, overflow: 'auto' }}>
+        {channels.map((channel) => (
+          <ListItem 
+            key={channel.id}
+            button
+            onClick={() => handleChannelClick(channel.id)}
+          >
+            <ListItemText 
+              primary={channel.title}
+              secondary={channel.last_message_preview || 'No messages yet'}
+            />
+          </ListItem>
+        ))}
+      </List>
+
+      <CreateChannelModal 
+        open={createModalOpen}
+        onClose={() => setCreateModalOpen(false)}
+        onChannelCreated={fetchChannels}
+      />
+      <JoinChannelModal 
+        open={joinModalOpen}
+        onClose={() => setJoinModalOpen(false)}
+        onChannelJoined={fetchChannels}
+      />
+    </Box>
+  );
+} 

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from 'react';
+import { Box, Typography, IconButton, Menu, MenuItem } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import MessageList from './MessageList';
+import MessageInput from './MessageInput';
+import { useAuth } from '../contexts/AuthContext';
+import { Channel, MessageV2 } from '../types/channel';
+import AddUserModal from './modals/AddUserModal';
+import LeaveChannelModal from './modals/LeaveChannelModal';
+import { useRouter } from 'next/router';
+
+interface ChannelViewProps {
+  channelId: string;
+}
+
+export default function ChannelView({ channelId }: ChannelViewProps) {
+  const [channel, setChannel] = useState<Channel | null>(null);
+  const [messages, setMessages] = useState<MessageV2[]>([]);
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [addUserOpen, setAddUserOpen] = useState(false);
+  const [leaveOpen, setLeaveOpen] = useState(false);
+  const { token, user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (channelId) {
+      fetchChannel();
+      fetchMessages();
+    }
+  }, [channelId]);
+
+  const fetchChannel = async () => {
+    try {
+      const response = await fetch(`/api/v2/channels/${channelId}`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setChannel(data);
+      } else if (response.status === 403) {
+        router.push('/');
+      }
+    } catch (error) {
+      console.error('Error fetching channel:', error);
+    }
+  };
+
+  const fetchMessages = async () => {
+    try {
+      const response = await fetch(`/api/v2/channels/${channelId}/messages`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setMessages(data.reverse()); // Display newest last
+      }
+    } catch (error) {
+      console.error('Error fetching messages:', error);
+    }
+  };
+
+  const handleSendMessage = async (content: string) => {
+    try {
+      const response = await fetch(`/api/v2/channels/${channelId}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ content })
+      });
+
+      if (response.ok) {
+        const newMessage = await response.json();
+        setMessages(prev => [...prev, newMessage]);
+      }
+    } catch (error) {
+      console.error('Error sending message:', error);
+    }
+  };
+
+  const handleLeaveChannel = async () => {
+    try {
+      await fetch(`/api/v2/channels/${channelId}/leave`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      router.push('/');
+    } catch (error) {
+      console.error('Error leaving channel:', error);
+    }
+  };
+
+  if (!channel) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography>Loading channel...</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Box sx={{ 
+        p: 2, 
+        borderBottom: 1, 
+        borderColor: 'divider',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between'
+      }}>
+        <Typography variant="h6">{channel.title}</Typography>
+        <IconButton onClick={(e) => setMenuAnchor(e.currentTarget)}>
+          <MoreVertIcon />
+        </IconButton>
+      </Box>
+
+      <MessageList messages={messages} currentUserId={user?.id} />
+      <MessageInput onSend={handleSendMessage} />
+
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={() => setMenuAnchor(null)}
+      >
+        <MenuItem onClick={() => {
+          setAddUserOpen(true);
+          setMenuAnchor(null);
+        }}>
+          Add User
+        </MenuItem>
+        <MenuItem onClick={() => {
+          setLeaveOpen(true);
+          setMenuAnchor(null);
+        }}>
+          Leave Channel
+        </MenuItem>
+      </Menu>
+
+      <AddUserModal
+        open={addUserOpen}
+        onClose={() => setAddUserOpen(false)}
+        channelId={channelId}
+      />
+      <LeaveChannelModal
+        open={leaveOpen}
+        onClose={() => setLeaveOpen(false)}
+        onConfirm={handleLeaveChannel}
+        channelTitle={channel.title}
+      />
+    </Box>
+  );
+} 

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,24 +1,23 @@
 import { Paper, Typography } from '@mui/material';
-import { Message } from '../types/chat';
+import { MessageV2 } from '../types/channel';
 
 interface MessageBubbleProps {
-  message: Message;
+  message: MessageV2;
+  isOwnMessage: boolean;
 }
 
-export default function MessageBubble({ message }: MessageBubbleProps) {
-  const isUser = message.sender === 'user';
-
+export default function MessageBubble({ message, isOwnMessage }: MessageBubbleProps) {
   return (
     <Paper
       elevation={1}
       sx={{
         p: 1,
         maxWidth: '70%',
-        alignSelf: isUser ? 'flex-end' : 'flex-start',
-        backgroundColor: isUser ? 'primary.light' : 'grey.100',
+        alignSelf: isOwnMessage ? 'flex-end' : 'flex-start',
+        backgroundColor: isOwnMessage ? 'primary.light' : 'grey.100',
       }}
     >
-      <Typography>{message.text}</Typography>
+      <Typography>{message.content}</Typography>
     </Paper>
   );
 } 

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { Box, TextField, IconButton } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+
+interface MessageInputProps {
+  onSend: (message: string) => void;
+}
+
+export default function MessageInput({ onSend }: MessageInputProps) {
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (message.trim()) {
+      onSend(message);
+      setMessage('');
+    }
+  };
+
+  return (
+    <Box 
+      component="form" 
+      onSubmit={handleSubmit}
+      sx={{ 
+        p: 2, 
+        borderTop: 1, 
+        borderColor: 'divider',
+        display: 'flex',
+        gap: 1
+      }}
+    >
+      <TextField
+        fullWidth
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        placeholder="Type a message..."
+        size="small"
+      />
+      <IconButton type="submit" color="primary">
+        <SendIcon />
+      </IconButton>
+    </Box>
+  );
+} 

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,39 +1,37 @@
 import { Box } from '@mui/material';
+import { MessageV2 } from '../types/channel';
 import MessageBubble from './MessageBubble';
-import { Message } from '../types/chat';
 import { useEffect, useRef } from 'react';
 
 interface MessageListProps {
-  messages: Message[];
+  messages: MessageV2[];
+  currentUserId: string;
 }
 
-export default function MessageList({ messages }: MessageListProps) {
-  const messagesEndRef = useRef<null | HTMLDivElement>(null);
-
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  };
+export default function MessageList({ messages, currentUserId }: MessageListProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    scrollToBottom();
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
   return (
-    <Box 
-      sx={{ 
-        flex: 1, 
-        overflowY: 'auto',
-        p: 2,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 1
-      }} 
-      data-testid="message-list"
-    >
+    <Box sx={{ 
+      flex: 1, 
+      overflow: 'auto',
+      p: 2,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 1
+    }}>
       {messages.map((message) => (
-        <MessageBubble key={message.id} message={message} />
+        <MessageBubble
+          key={message.id}
+          message={message}
+          isOwnMessage={message.user_id === currentUserId}
+        />
       ))}
-      <div ref={messagesEndRef} />
+      <div ref={bottomRef} />
     </Box>
   );
 } 

--- a/src/components/modals/AddUserModal.tsx
+++ b/src/components/modals/AddUserModal.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { 
+  Dialog, 
+  DialogTitle, 
+  DialogContent, 
+  DialogActions, 
+  Button, 
+  TextField,
+  Alert
+} from '@mui/material';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface AddUserModalProps {
+  open: boolean;
+  onClose: () => void;
+  channelId: string;
+}
+
+export default function AddUserModal({ open, onClose, channelId }: AddUserModalProps) {
+  const [userIdentifier, setUserIdentifier] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const { token } = useAuth();
+
+  const handleSubmit = async () => {
+    if (!userIdentifier.trim()) {
+      setError('User identifier is required');
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/v2/channels/${channelId}/invite`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ userIdentifier })
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.message || 'Failed to add user');
+      }
+
+      handleClose();
+    } catch (error) {
+      console.error('Error adding user:', error);
+      setError(error.message);
+    }
+  };
+
+  const handleClose = () => {
+    setUserIdentifier('');
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Add User to Channel</DialogTitle>
+      <DialogContent>
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+        <TextField
+          autoFocus
+          margin="dense"
+          label="User Email or Nickname"
+          fullWidth
+          value={userIdentifier}
+          onChange={(e) => setUserIdentifier(e.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleSubmit}>Add</Button>
+      </DialogActions>
+    </Dialog>
+  );
+} 

--- a/src/components/modals/CreateChannelModal.tsx
+++ b/src/components/modals/CreateChannelModal.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { 
+  Dialog, 
+  DialogTitle, 
+  DialogContent, 
+  DialogActions, 
+  Button, 
+  TextField,
+  FormControlLabel,
+  Switch,
+  Alert
+} from '@mui/material';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface CreateChannelModalProps {
+  open: boolean;
+  onClose: () => void;
+  onChannelCreated: () => void;
+}
+
+export default function CreateChannelModal({ open, onClose, onChannelCreated }: CreateChannelModalProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { token } = useAuth();
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/v2/channels', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          title,
+          description: description.trim() || undefined,
+          is_private: isPrivate
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+
+      onChannelCreated();
+      handleClose();
+    } catch (error) {
+      console.error('Error creating channel:', error);
+      setError('Failed to create channel');
+    }
+  };
+
+  const handleClose = () => {
+    setTitle('');
+    setDescription('');
+    setIsPrivate(false);
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Create New Channel</DialogTitle>
+      <DialogContent>
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+        <TextField
+          autoFocus
+          margin="dense"
+          label="Channel Title"
+          fullWidth
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <TextField
+          margin="dense"
+          label="Description (optional)"
+          fullWidth
+          multiline
+          rows={2}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={isPrivate}
+              onChange={(e) => setIsPrivate(e.target.checked)}
+            />
+          }
+          label="Private Channel"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleSubmit}>Create</Button>
+      </DialogActions>
+    </Dialog>
+  );
+} 

--- a/src/components/modals/JoinChannelModal.tsx
+++ b/src/components/modals/JoinChannelModal.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { 
+  Dialog, 
+  DialogTitle, 
+  DialogContent, 
+  DialogActions, 
+  Button, 
+  TextField,
+  Alert
+} from '@mui/material';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface JoinChannelModalProps {
+  open: boolean;
+  onClose: () => void;
+  onChannelJoined: () => void;
+}
+
+export default function JoinChannelModal({ open, onClose, onChannelJoined }: JoinChannelModalProps) {
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const { token } = useAuth();
+
+  const handleSubmit = async () => {
+    if (!/^[A-Z0-9]{6}$/.test(code)) {
+      setError('Invalid channel code format');
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/v2/channels/join-by-code/${code}`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.message || 'Failed to join channel');
+      }
+
+      onChannelJoined();
+      handleClose();
+    } catch (error) {
+      console.error('Error joining channel:', error);
+      setError(error.message);
+    }
+  };
+
+  const handleClose = () => {
+    setCode('');
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Join Channel</DialogTitle>
+      <DialogContent>
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+        <TextField
+          autoFocus
+          margin="dense"
+          label="Channel Code"
+          fullWidth
+          value={code}
+          onChange={(e) => setCode(e.target.value.toUpperCase())}
+          placeholder="Enter 6-character code"
+          inputProps={{ maxLength: 6 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleSubmit}>Join</Button>
+      </DialogActions>
+    </Dialog>
+  );
+} 

--- a/src/components/modals/LeaveChannelModal.tsx
+++ b/src/components/modals/LeaveChannelModal.tsx
@@ -1,0 +1,37 @@
+import { 
+  Dialog, 
+  DialogTitle, 
+  DialogContent, 
+  DialogActions, 
+  Button,
+  Typography
+} from '@mui/material';
+
+interface LeaveChannelModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  channelTitle: string;
+}
+
+export default function LeaveChannelModal({ 
+  open, 
+  onClose, 
+  onConfirm, 
+  channelTitle 
+}: LeaveChannelModalProps) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Leave Channel</DialogTitle>
+      <DialogContent>
+        <Typography>
+          Are you sure you want to leave "{channelTitle}"? You'll need an invitation to rejoin.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onConfirm} color="error">Leave</Button>
+      </DialogActions>
+    </Dialog>
+  );
+} 

--- a/src/pages/api/v2/channels/[channelId]/index.ts
+++ b/src/pages/api/v2/channels/[channelId]/index.ts
@@ -1,0 +1,56 @@
+import { NextApiResponse } from 'next';
+import { withAuth, AuthenticatedRequest } from '../../../../../middleware/auth';
+import { ChannelService } from '../../../../../services/channelService';
+
+const channelService = new ChannelService();
+
+// MANUAL: adding missing Get Channel API
+
+/**
+ * @swagger
+ * /api/v2/channels/{channelId}:
+ *   get:
+ *     summary: Get channel info
+ *     description: The user must be a channel member
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: channelId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Channel info
+ *       401:
+ *         description: Unauthorized
+ *       403:
+ *         description: Not a channel member
+ */
+async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
+    const { channelId } = req.query;
+
+    if (typeof channelId !== 'string') {
+        console.error('Invalid channel ID');
+        return res.status(400).json({ message: 'Invalid channel ID' });
+    }
+
+    try {
+         if (req.method === 'GET') {
+            const channelInfo = await channelService.getChannelInfo(channelId, req.user!.id);
+            res.status(200).json(channelInfo);
+        } else {
+            res.status(405).json({ message: 'Method not allowed' });
+        }
+    } catch (error) {
+        console.error('Error handling channel info:', error);
+        if (error.message === 'User is not a member of this channel') {
+            return res.status(403).json({ message: error.message });
+        }
+        res.status(500).json({ message: 'Internal server error' });
+    }
+}
+
+export default withAuth(handler); 

--- a/src/pages/channels/[channelId].tsx
+++ b/src/pages/channels/[channelId].tsx
@@ -1,0 +1,29 @@
+import { Box } from '@mui/material';
+import { useRouter } from 'next/router';
+import AuthHeader from '../../components/AuthHeader';
+import ChannelList from '../../components/ChannelList';
+import ChannelView from '../../components/ChannelView';
+import { AuthProvider } from '../../contexts/AuthContext';
+
+export default function ChannelPage() {
+  const router = useRouter();
+  const { channelId } = router.query;
+
+  return (
+    <AuthProvider>
+      <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+        <AuthHeader />
+        <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          <Box sx={{ width: '30%', borderRight: 1, borderColor: 'divider' }}>
+            <ChannelList />
+          </Box>
+          <Box sx={{ flex: 1 }}>
+            {channelId && typeof channelId === 'string' && (
+              <ChannelView channelId={channelId} />
+            )}
+          </Box>
+        </Box>
+      </Box>
+    </AuthProvider>
+  );
+} 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
-import { Box } from '@mui/material';
-import ChatInterface from '../components/ChatInterface';
+import { Box, Typography } from '@mui/material';
 import AuthHeader from '../components/AuthHeader';
+import ChannelList from '../components/ChannelList';
 import { AuthProvider } from '../contexts/AuthContext';
 
 export default function Home() {
@@ -8,7 +8,16 @@ export default function Home() {
     <AuthProvider>
       <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
         <AuthHeader />
-        <ChatInterface />
+        <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          <Box sx={{ width: '30%', borderRight: 1, borderColor: 'divider' }}>
+            <ChannelList />
+          </Box>
+          <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            <Typography color="text.secondary">
+              Select a channel to start chatting
+            </Typography>
+          </Box>
+        </Box>
       </Box>
     </AuthProvider>
   );

--- a/src/services/channelService.ts
+++ b/src/services/channelService.ts
@@ -144,6 +144,33 @@ export class ChannelService {
         return result.rows;
     }
 
+    // MANUAL
+    /**
+     * Get channel info
+     * The user must be a channel member
+     */
+    async getChannelInfo(
+        channelId: string,
+        userId: string
+    ): Promise<Channel> {
+        // Verify user is member of channel
+        const memberCheck = await pool.query(
+            `SELECT 1 FROM channel_members 
+            WHERE channel_id = $1 AND user_id = $2`,
+            [channelId, userId]
+        );
+        
+        if (memberCheck.rowCount === 0) {
+            throw new Error('User is not a member of this channel');
+        }
+        
+        // Get Channel Info
+        const channelResult = await pool.query(
+            `SELECT * from channels where id = $1 limit 1`, [channelId]
+        );
+        return channelResult.rows[0];
+    }
+
     /**
      * Join a channel using its code
      * Join a public channel using its 6-character code

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -7,15 +7,11 @@ export interface Region {
 export interface Channel {
     id: string;
     code: string;
-    region_id: string;
     title: string;
     description?: string;
     is_private: boolean;
-    state: 'ACTIVE' | 'DELETED';
-    owner_id: string;
     last_message_preview?: string;
     last_message_date?: Date;
-    creation_date: Date;
 }
 
 export interface ChannelMember {
@@ -37,13 +33,5 @@ export interface MessageV2 {
     channel_id: string;
     user_id: string;
     content: string;
-    content_preview: string;
-    kind: 'TEXT';
-    is_deleted: boolean;
     creation_date: Date;
-}
-
-export interface CreateMessageV2Dto {
-    channel_id: string;
-    content: string;
 } 

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -7,11 +7,15 @@ export interface Region {
 export interface Channel {
     id: string;
     code: string;
+    region_id: string;
     title: string;
     description?: string;
     is_private: boolean;
+    state: 'ACTIVE' | 'DELETED';
+    owner_id: string;
     last_message_preview?: string;
     last_message_date?: Date;
+    creation_date: Date;
 }
 
 export interface ChannelMember {
@@ -33,5 +37,14 @@ export interface MessageV2 {
     channel_id: string;
     user_id: string;
     content: string;
+    content_preview: string;
+    kind: 'TEXT';
+    is_deleted: boolean;
     creation_date: Date;
 } 
+
+
+export interface CreateMessageV2Dto {
+    channel_id: string;
+    content: string;
+}


### PR DESCRIPTION
Took one prompt with actual task, and one more to "continue with all other changes.
Prompt was enriched to forbid cursor do massive library replacements (e.g. next-auth) - which makes sence, but no more free credits


> @Codebase 
> 
> It's time to change the UI to use v2 channel and messages API, leave the old messages API alone.
> 
> The UI as it was goes away and is replaced with the following, implementing a very simple messaging app with channels:
> 
> 1. The top panel stays as is with log in / sign up /logout buttons
> 2.Main screen is divided vertically approx 30/70%. For non-authenticated users both are empty.
> 3. Left pannel is the list of channels the user is member of. At the top there are two buttons: Create Channel and Join Channel.
> 3.1 Create Channel asks for parameters and creates a channel. Basic error handling.
> 3.2 Join channel asks for 6-char code and tries to join the channel. Basic error handling.
> 3.3 On click on a channel, the list of its messages is loaded to the right panel. The panel has subheader with name of the channel and ... menu. At the bottom usual control to type a message and send button.
> 4.1. URL changes when a channel is opened, so the app could be loaded by the link
> 4.2 When loading channel, basic error handling if the user is not a member etc. to handle loading by URL
> 4.3. When a user sends message, their message is displayed immediately. In order to see messages of other users, the user would have to re-open the channel or reload the app. For simplicity we postpone messages polling, websocket and alike.
> 5. There are two items in channels ... menu: Add user and leave channel
> 5.1 add user asks for their ID and adds them
> 5.2 leave channel asks for a confirmation
> 6. There's no way yet to see channels the user is not a member off
> 
> It's expected there's enough APIs to cover these use cases, try using the APIs and not introduce new ones unless confirmed by the user. 
> 
> Also keep the app construct as it was: 
> a) still Next.js, 
> b) still Material UI, 
> c) still the same way to connect to DB, 
> d) still the same way to authenticate user and authenticate API requests (no switch to next-auth at this point).  
> 
> Follow Contributing Guidelines - besides don't change the e2e UI test for now, make a note in Changelog.|
